### PR TITLE
Add templates to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include HISTORY.md
 include LICENSE
 include README.md
 
+recursive-include autobazaar/templates *.json
+
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Add templates to `MANIFEST.in` to ensure that they are included in the distributed package.

Related to the errors reported in #20